### PR TITLE
--message-body now can be passed a @filename to pull json from

### DIFF
--- a/src/BuslyCLI.Console/Commands/CommonMessageSettings.cs
+++ b/src/BuslyCLI.Console/Commands/CommonMessageSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using BuslyCLI.TypeConverters;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -25,15 +26,24 @@ public abstract class CommonMessageSettings : GlobalCommandSettings
     public required string EnclosedMessageType { get; set; }
 
     [CommandOption("-m|--message-body <message-body>")]
-    [Description("The content of the message body")]
-    public required string MessageBody { get; set; }
+    [Description("The content of the message body. Accepts a raw JSON string or a path to a file using curl-style @file syntax (e.g. @payload.json).")]
+    public required MessageBodyValue MessageBody { get; set; }
 
     public override ValidationResult Validate()
     {
         if (string.IsNullOrWhiteSpace(ContentType)) return ValidationResult.Error("must specify a 'content-type'.");
         if (string.IsNullOrWhiteSpace(EnclosedMessageType))
             return ValidationResult.Error("must specify an 'enclosed-message-type'.");
-        if (string.IsNullOrWhiteSpace(MessageBody)) return ValidationResult.Error("must specify a 'message-body'.");
+
+        if (MessageBody is null) return ValidationResult.Error("must specify a 'message-body'.");
+        if (Path.IsPathFullyQualified(MessageBody.Value))
+        {
+            if (!File.Exists(MessageBody.Value))
+                return ValidationResult.Error($"File not found: {MessageBody.Value}");
+
+            MessageBody.Value = File.ReadAllText(MessageBody.Value);
+        }
+
         return base.Validate();
     }
 

--- a/src/BuslyCLI.Console/Commands/NsbCommand/SendCommand.cs
+++ b/src/BuslyCLI.Console/Commands/NsbCommand/SendCommand.cs
@@ -27,7 +27,7 @@ public class SendCommand(IRawEndpointFactory rawEndpointFactory, INServiceBusCon
         var message = new OutgoingMessage(
             Guid.NewGuid().ToString(),
             headers,
-            Encoding.ASCII.GetBytes(settings.MessageBody)
+            Encoding.ASCII.GetBytes(settings.MessageBody.Value)
         );
 
         var transportOperation = new TransportOperation(

--- a/src/BuslyCLI.Console/Commands/NsbEvent/PublishCommand.cs
+++ b/src/BuslyCLI.Console/Commands/NsbEvent/PublishCommand.cs
@@ -30,7 +30,7 @@ public class PublishCommand(IRawEndpointFactory rawEndpointFactory, INServiceBus
         var message = new OutgoingMessage(
             Guid.NewGuid().ToString(),
             headers,
-            Encoding.ASCII.GetBytes(settings.MessageBody)
+            Encoding.ASCII.GetBytes(settings.MessageBody.Value)
         );
 
         var type = CreateTypeFromString(settings.EnclosedMessageType);

--- a/src/BuslyCLI.Console/Commands/NsbTimeout/SendTimeout.cs
+++ b/src/BuslyCLI.Console/Commands/NsbTimeout/SendTimeout.cs
@@ -46,7 +46,7 @@ public class SendTimeout(IAnsiConsole console, IRawEndpointFactory rawEndpointFa
         var message = new OutgoingMessage(
             Guid.NewGuid().ToString(),
             headers,
-            Encoding.ASCII.GetBytes(settings.MessageBody)
+            Encoding.ASCII.GetBytes(settings.MessageBody.Value)
         );
 
         var dispatchProperties = new DispatchProperties();

--- a/src/BuslyCLI.Console/TypeConverters/MessageBodyTypeConverter.cs
+++ b/src/BuslyCLI.Console/TypeConverters/MessageBodyTypeConverter.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+
+namespace BuslyCLI.TypeConverters;
+
+public class MessageBodyTypeConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    {
+        return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+    }
+
+    public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+    {
+
+        if (value is string str)
+        {
+            // Curl-style @file reference: parse only, no I/O
+            if (str.StartsWith("@"))
+            {
+                var expandedFilePath = new ExpandedPath(str[1..]);
+                return new MessageBodyValue(expandedFilePath.Path);
+            }
+        }
+
+        return base.ConvertFrom(context, culture, value);
+    }
+}

--- a/src/BuslyCLI.Console/TypeConverters/MessageBodyValue.cs
+++ b/src/BuslyCLI.Console/TypeConverters/MessageBodyValue.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+
+namespace BuslyCLI.TypeConverters;
+
+[TypeConverter(typeof(MessageBodyTypeConverter))]
+public class MessageBodyValue
+{
+    public string Value { get; set; }
+
+
+    public MessageBodyValue(string value)
+    {
+        Value = value;
+    }
+}

--- a/tests/BuslyCLI.Console.Tests/Commands/CommonCommandSettingsTests.cs
+++ b/tests/BuslyCLI.Console.Tests/Commands/CommonCommandSettingsTests.cs
@@ -1,4 +1,5 @@
 using BuslyCLI.Commands.NsbCommand;
+using BuslyCLI.TypeConverters;
 
 namespace BuslyCLI.Console.Tests.Commands;
 
@@ -12,7 +13,7 @@ public class CommonCommandSettingsTests
         {
             ContentType = "application/json",
             EnclosedMessageType = "MessageContracts.Commands.CreateOrder",
-            MessageBody = "{}",
+            MessageBody = new MessageBodyValue("{}"),
             DestinationEndpoint = null!
         };
 

--- a/tests/BuslyCLI.Console.Tests/Commands/CommonMessageSettingsTests.cs
+++ b/tests/BuslyCLI.Console.Tests/Commands/CommonMessageSettingsTests.cs
@@ -1,4 +1,5 @@
 using BuslyCLI.Commands.NsbEvent;
+using BuslyCLI.TypeConverters;
 
 namespace BuslyCLI.Console.Tests.Commands;
 
@@ -12,7 +13,7 @@ public class CommonMessageSettingsTests
         {
             ContentType = null!,
             EnclosedMessageType = "MessageContracts.Commands.CreateOrder",
-            MessageBody = "{}"
+            MessageBody = new MessageBodyValue("{}")
         };
 
         var result = settings.Validate();
@@ -28,7 +29,7 @@ public class CommonMessageSettingsTests
         {
             ContentType = "application/json",
             EnclosedMessageType = null!,
-            MessageBody = "{}"
+            MessageBody = new MessageBodyValue("{}")
         };
 
         var result = settings.Validate();
@@ -51,5 +52,22 @@ public class CommonMessageSettingsTests
 
         Assert.That(result.Successful, Is.False);
         Assert.That(result.Message, Does.Contain("must specify a 'message-body'."));
+    }
+
+    [Test]
+    public void ShouldFailWhenMessageBodyFileDoesNotExist()
+    {
+        var nonExistentFilePath = Path.GetFullPath("non-existent-payload.json");
+        var settings = new PublishCommandSettings
+        {
+            ContentType = "application/json",
+            EnclosedMessageType = "MessageContracts.Commands.CreateOrder",
+            MessageBody = new MessageBodyValue(nonExistentFilePath)
+        };
+
+        var result = settings.Validate();
+
+        Assert.That(result.Successful, Is.False);
+        Assert.That(result.Message, Does.Contain($"File not found: {nonExistentFilePath}"));
     }
 }

--- a/website/docs/cli-reference/command/send.md
+++ b/website/docs/cli-reference/command/send.md
@@ -14,8 +14,7 @@ busly send command
 | ------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `-c`, `--content-type`          | The fully qualified .NET type name of the enclosed message (ex: Ordering.Commands.CreateOrder ) |
 | `-e`, `--enclosed-message-type` | The type of serialization used for the message                                                  |
-| `-m`, `--message-body`          | The content of the message body                                                                 |
-| `-d`, `--destination-endpoint`  | The destination endpoint to send a message to                                                   |
+| `-m`, `--message-body`          | The content of the message body. Accepts a raw JSON string or a path to a file using curl-style `@` syntax (e.g. `@payload.json`). |
 
 ## Examples
 

--- a/website/docs/cli-reference/event/publish.md
+++ b/website/docs/cli-reference/event/publish.md
@@ -14,7 +14,7 @@ busly event publish
 | ------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `-c`, `--content-type`          | The fully qualified .NET type name of the enclosed message (ex: Ordering.Commands.CreateOrder ) |
 | `-e`, `--enclosed-message-type` | The type of serialization used for the message                                                  |
-| `-m`, `--message-body`          | The content of the message body                                                                 |
+| `-m`, `--message-body`          | The content of the message body. Accepts a raw JSON string or a path to a file using curl-style `@` syntax (e.g. `@payload.json`). |
 
 ## Examples
 

--- a/website/docs/cli-reference/timeout/send.md
+++ b/website/docs/cli-reference/timeout/send.md
@@ -14,7 +14,7 @@ busly timeout send
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `-c`, `--content-type`          | The fully qualified .NET type name of the enclosed message (ex: Ordering.Commands.CreateOrder )                   |
 | `-e`, `--enclosed-message-type` | The type of serialization used for the message                                                                    |
-| `-m`, `--message-body`          | The content of the message body                                                                                   |
+| `-m`, `--message-body`          | The content of the message body. Accepts a raw JSON string or a path to a file using curl-style `@` syntax (e.g. `@payload.json`). |
 | `-d`, `--destination-endpoint`  | The destination endpoint to send a message to                                                                     |
 | `--do-not-deliver-before`       | Allows specifying a date before which the delivery should not occur, using ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ) |
 | `--delay-delivery-with`         | Specifies the delay before the timeout is delivered, using a TimeSpan format                                      |

--- a/website/docs/introduction/quick-start.mdx
+++ b/website/docs/introduction/quick-start.mdx
@@ -291,3 +291,80 @@ docker run --rm `
 
 </TabItem>
 </Tabs>
+
+## Passing Message Body from a File
+
+As you can see in the commands above, inlining JSON directly in the terminal can get complicated fast — especially in PowerShell, where double quotes require manual escaping. For anything beyond the simplest payloads, this becomes error-prone and hard to read.
+
+Busly supports a curl-style `@filename` syntax for `--message-body`, letting you store your JSON in a file and reference it directly. Where `payload.json` contains:
+
+```json
+{
+  "OrderNumber": "3f2d6c8a-b7a2-4c3f-9c3e-12ab45ef6789"
+}
+```
+
+<Tabs>
+<TabItem value="bash" label="Bash">
+
+```bash
+busly command send \
+  --content-type 'text/json' \
+  --enclosed-message-type "Messages.Commands.CreateOrder" \
+  --destination-endpoint "BuslyCLI.DemoEndpoint" \
+  --message-body @payload.json
+```
+
+</TabItem>
+<TabItem value="powershell" label="PowerShell">
+
+```bash
+busly command send `
+  --content-type 'text/json' `
+  --enclosed-message-type "Messages.Commands.CreateOrder" `
+  --destination-endpoint "BuslyCLI.DemoEndpoint" `
+  --message-body @payload.json
+```
+
+</TabItem>
+<TabItem value="docker bash" label="Docker (Bash)">
+
+When running via Docker, mount the payload file into the container using `-v` and reference its container path with `@`:
+
+```bash
+docker run --rm \
+  --network host \
+  -v "$HOME/.busly-cli/config.yaml:/app/config.yaml" \
+  -v "$(pwd)/payload.json:/app/payload.json" \
+  tragiccode/busly-cli \
+  command send \
+    --content-type "text/json" \
+    --enclosed-message-type "Messages.Commands.CreateOrder" \
+    --destination-endpoint "BuslyCLI.DemoEndpoint" \
+    --message-body @/app/payload.json \
+    --config ./config.yaml
+```
+
+</TabItem>
+<TabItem value="docker powershell" label="Docker (PowerShell)">
+
+When running via Docker, mount the payload file into the container using `-v` and reference its container path with `@`:
+
+```bash
+docker run --rm `
+  --network host `
+  -v "$HOME/.busly-cli/config.yaml:/app/config.yaml" `
+  -v "${PWD}/payload.json:/app/payload.json" `
+  tragiccode/busly-cli `
+  command send `
+    --content-type "text/json" `
+    --enclosed-message-type "Messages.Commands.CreateOrder" `
+    --destination-endpoint "BuslyCLI.DemoEndpoint" `
+    --message-body @/app/payload.json `
+    --config ./config.yaml
+```
+
+</TabItem>
+</Tabs>
+
+No escaping required on any platform. Relative paths are resolved from your current working directory, and `~` is expanded to your home directory.


### PR DESCRIPTION
Implement a cross-platform what to send the message body through a file on the file system. This helps avoid some of the shenanigans with terminal escaping of json (most specifically with powershell!!).